### PR TITLE
Update image to RHEL 10.2 (rhel-10-2-eus-06-08-26)

### DIFF
--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -6,6 +6,7 @@ virtualmachines:
     memory: "4G"
     cores: 1
     image_size: "40G"
+    register_satellite: false
     tags:
       - key: "AnsibleGroup"
         value: "bastions"

--- a/setup-automation/setup-rhel.sh
+++ b/setup-automation/setup-rhel.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# Create an output file
 # Unregister and register the VM
 subscription-manager clean
 subscription-manager register --activationkey=12-5-22-instruqt --org=12451665 --force
 
+# Create an output file
 touch /root/post-run.log
 
 # Create a done file to signal we have finished

--- a/setup-automation/setup-rhel.sh
+++ b/setup-automation/setup-rhel.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
 # Create an output file
+# Unregister and register the VM
+subscription-manager clean
+subscription-manager register --activationkey=12-5-22-instruqt --org=12451665 --force
+
 touch /root/post-run.log
 
 # Create a done file to signal we have finished


### PR DESCRIPTION
## Summary
- Updated `instances.yaml` image to `rhel-10-2-eus-06-08-26`
- Disabled satellite registration (`register_satellite: false`)
- Commented out packages block
- Added subscription-manager clean & re-register to `setup-rhel.sh`
- Part of RHEL 10.2 lab migration

## Lab
Design and build virtual machine images using commandline tools [Image Builder]